### PR TITLE
Move version to end of each TTY log filename

### DIFF
--- a/tty-log-head
+++ b/tty-log-head
@@ -17,8 +17,8 @@ set -eo pipefail
 unalias -a
 
 _get_home () {
-        # cf. <https://superuser.com/a/484330>
-        getent passwd "$1"|cut -d: -f6
+    # cf. <https://superuser.com/a/484330>
+    getent passwd "$1"|cut -d: -f6
 }
 
 [[ $HOME == $(_get_home $EUID) ]] || {
@@ -34,19 +34,19 @@ echo -e "$_usage\n"\
 exit 1
 } >&2
 
-let _version=$1
+_version="$(($1))"
 
 (( $_version >= 0 )) || {
-echo -e "$_usage"\
+echo -e "$_usage\n"\
 "$0: error: argument VERSION: '$_version' is not a non-negative integer"
 exit 1
 } >&2
 
-_tty_log_filename_prefix="$HOME/var/log/tty"
+_default_tty_log_filename="$HOME/var/log/tty.log"
 
 if (( $_version == 0 ))
-then exec 3< "$_tty_log_filename_prefix.log"
-else exec 3< "$_tty_log_filename_prefix.$_version.log"
+then exec 3< "$_default_tty_log_filename"
+else exec 3< "$_default_tty_log_filename.$_version"
 fi
 
 sed -n '2p' <&3

--- a/tty-logger
+++ b/tty-logger
@@ -17,8 +17,8 @@ set -eo pipefail
 unalias -a
 
 _get_home () {
-        # cf. <https://superuser.com/a/484330>
-        getent passwd "$1"|cut -d: -f6
+    # cf. <https://superuser.com/a/484330>
+    getent passwd "$1"|cut -d: -f6
 }
 
 [[ $HOME == $(_get_home $EUID) ]] || {
@@ -29,35 +29,33 @@ exit 1
 _tty_logger_directory="$HOME/var/log"
 install -d "$_tty_logger_directory"
 {
-        _tty_log_filename_prefix="$_tty_logger_directory/tty"
-        _default_tty_log_filename="$_tty_log_filename_prefix.log"
-        _tty_log_filename_version_pattern='tty\.([1-9][0-9]*)\.log'
+_default_tty_log_filename="$_tty_logger_directory/tty.log"
 
-        if [[ -e $_default_tty_log_filename ]]
-        then exec 3> "$_tty_log_filename_prefix.$(($({
-                for _string in $_tty_logger_directory/*
-                do
-                        if [[ $_string =~ $_tty_log_filename_version_pattern ]]
-                        then echo "${BASH_REMATCH[1]}"
-                        fi
-                done
-        }|sort -nr|head -n1) + 1)).log"
-        else exec 3> "$_default_tty_log_filename"
+if [[ -e $_default_tty_log_filename ]]
+then exec 3> "$_default_tty_log_filename.$(($({
+    for _string in $_tty_logger_directory/*
+    do
+        if [[ ${_string#$_default_tty_log_filename} =~ ^\.([1-9][0-9]*)$ ]]
+        then echo "${BASH_REMATCH[1]}"
         fi
+    done
+}|sort -nr|head -n1) + 1))"
+else exec 3> "$_default_tty_log_filename"
+fi
 } 4> "$_tty_logger_directory/.lock"
 _date_format='+%Y-%m-%dT%H:%M:%S%:z'
 
 _format () {
-        while IFS= read -r x
-        do stdbuf -o0 -e0 printf "%s %s%s%s\n" "$(
-                stdbuf -o0 -e0 date "$_date_format")" "$1" "$x" "$2"
-        done
+    while IFS= read -r x
+    do stdbuf -o0 -e0 printf "%s %s%s%s\n" "$(
+        stdbuf -o0 -e0 date "$_date_format")" "$1" "$x" "$2"
+    done
 }
 
 date "$_date_format" >&3
 echo "$@" >&3
 { { { { { {
-        "$@" 4>&-|tee /dev/stderr 2>&4 4>&-
+    "$@" 4>&-|tee /dev/stderr 2>&4 4>&-
 } 2>&1 >&6|tee /dev/stderr 2>&5 4>&- 5>&- 6>&-
 } >&7
 } 6>&1|_format >&3 4>&- 5>&- 6>&- 7>&-

--- a/tty-logger-log
+++ b/tty-logger-log
@@ -17,8 +17,8 @@ set -eo pipefail
 unalias -a
 
 _get_home () {
-        # cf. <https://superuser.com/a/484330>
-        getent passwd "$1"|cut -d: -f6
+    # cf. <https://superuser.com/a/484330>
+    getent passwd "$1"|cut -d: -f6
 }
 
 [[ $HOME == $(_get_home $EUID) ]] || {
@@ -27,14 +27,14 @@ exit 1
 } >&2
 
 _tty_logger_directory="$HOME/var/log"
-_tty_log_filename_prefix="$_tty_logger_directory/tty"
-_default_tty_log_filename="$_tty_log_filename_prefix.log"
-
-{[[ -e $_default_tty_log_filename ]] && _default_tty_log_exists="$?"} ||
-        _default_tty_log_exists="$?"
+_default_tty_log_filename="$_tty_logger_directory/tty.log"
+_default_tty_log_exists="$({
+[[ -e $_default_tty_log_filename ]]
+echo "$?"
+})"
 
 _format () {
-        echo -e "\E[33mlog $1\E[m\n"\
+    echo -e "\E[33mlog $1\E[m\n"\
 "Date: $(date -d "$(head -n1 "$1")" '+%a %b %d %H:%M:%S %Y %z')\n"\
 "\n"\
 "    $(sed -n '2p' "$1")"
@@ -42,21 +42,17 @@ _format () {
 
 {
 for _tty_log_filename_version in $({
-        _tty_log_filename_version_pattern='tty\.([1-9][0-9]*)\.log'
-
-        for _string in $_tty_logger_directory/*
-        do
-                if [[ $_string =~ $_tty_log_filename_version_pattern ]]
-                then echo "${BASH_REMATCH[1]}"
-                fi
-        done
+    for _string in $_tty_logger_directory/*
+    do
+        if [[ ${_string#$_default_tty_log_filename} =~ ^\.([1-9][0-9]*)$ ]]
+        then echo "${BASH_REMATCH[1]}"
+        fi
+    done
 }|sort -nr)
 do
-        _format "$_tty_log_filename_prefix."\
-"$_tty_log_filename_version"\
-.log
-        [[ ! $_default_tty_log_exists ]] || echo
+    _format "$_default_tty_log_filename.$_tty_log_filename_version"
+    [[ ! $_default_tty_log_exists ]] || echo
 done
 
-_format "$_default_tty_log_filename"
+[[ ! $_default_tty_log_exists ]] || _format "$_default_tty_log_filename"
 }|less -FRX


### PR DESCRIPTION
Also fix premature exit bug with VERSION '0' in tty-log-head, change shiftwidth to 4, and improve regex matching

Before, a pattern that should have been at the very end of a TTY log's filename was matched against the complete TTY log's filename.  Now, the default TTY log filename, which, thanks to the main feature of this PR, is also the prefix for all other TTY log filenames, is removed from the complete TTY log's filename, leaving only a period followed by the version, e.g. '.1'.  This looks simpler and prevents false positives that would arise when the complete TTY log's filename, perhaps '/home/matthew/var/log/tty.log.1.log', only contains the pattern.